### PR TITLE
Refine indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ keys.yml
 secrets.yml
 
 requirements.txt
+
+# App specific
+index/

--- a/README.MD
+++ b/README.MD
@@ -1,11 +1,13 @@
 # eQ Suggest API
 
 EQ Suggest API provides a simple ReST service that enables a range of data
-sets to be queried with arbitrary terms.  Given a term the API will return a
-set of candidate matches that take an incomplete term, misspellings and typos
-into account.  The API also exposes each data set as paginated resources.
+sets to be queried with arbitrary terms.  Given a query term the API will
+return a set of candidate matches.  Incomplete query terms and misspellings
+(based on single character insertion and deletion) are taken into account.
+The API also exposes each data set as paginated resources.
 
-You can either build and run a docker container or run in a virtual environment**.  First, clone the repo:
+You can either build and run a docker container or run in a virtual environment.
+First, clone the repo:
 
   ```bash
    $ git clone git@github.com:ONSdigital/eq-suggest-api.git

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,14 +99,15 @@ def _get_suggestions(data_set_source, query, page_size, strategy):
     :param (str) data_set_source: Data set to query.
     :param (str) query: Query string.
     :param (str) strategy: Search strategy to use.
-    :returns (list): List of 10 candidates
+    :returns (list): List of candidate matches.
     """
-    if strategy not in ALL_STRATEGIES:
-        abort(400)
     if strategy == simple.STRATEGY_NAME:
         g = simple.Simple(data_set_source, max_matches=page_size)
-    else:
+    elif strategy == guess.STRATEGY_NAME:
         g = guess.Guess(data_set_source, max_matches=page_size)
+    else:
+        g = None
+        abort(400)
     g.init()
     return g.candidates(query)
 

--- a/app/guess.py
+++ b/app/guess.py
@@ -279,19 +279,6 @@ class PhraseLookup:
         inserts = [a + c + b for a, b in splits for c in charset]
         return set(deletes + inserts)
 
-    @staticmethod
-    def _double_edits(word):
-        """Set of double edits.
-
-        Using single edit misspellings returns a set of words that are two
-        edits away.
-
-        :param (str) word: Word to generate edits for.
-        :returns (set): The set of all double edits.
-        """
-        return set(e2 for e1 in PhraseLookup._single_edits(word)
-                   for e2 in PhraseLookup._single_edits(e1))
-
     def _known(self, words):
         """Set of known words.
 
@@ -314,7 +301,6 @@ class PhraseLookup:
         """
         candidates = (self._known({word}) or
                       self._known(self._single_edits(word)) or
-                      # self._known(self._double_edits(word)) or
                       {word})
         return max(candidates, key=self.model.get)
 

--- a/app/simple.py
+++ b/app/simple.py
@@ -1,0 +1,85 @@
+"""Simple Guess module.
+
+Builds a really simple index.
+"""
+import json
+
+from collections import defaultdict
+
+from logbook import Logger
+
+import app.strategy as strategy
+
+log = Logger(__name__)
+
+
+STRATEGY_NAME = 'simple'
+
+
+class Simple(strategy.Strategy):
+    """Simple.
+
+    Performs a simple lookup of a term.
+    """
+    MIN_N_GRAM_SIZE = 3
+
+    def __init__(self, data_file, max_matches=10):
+        """Constructor.
+
+        :param (str) data_file: Path to the json file data file.
+        :param (int) max_matches: Maximum matches to return, default is 10.
+        """
+        self.max_matches = max_matches
+        self.index = None
+        super().__init__(data_file, STRATEGY_NAME)
+
+    def init(self):
+        """Initialise.
+
+        Calls base implementation to load or lazily build the index.
+        """
+        self.index = super().init()
+
+    def candidates(self, query):
+        """Get candidate matches.
+
+        Main interface of the class, given a query returns a list of candidate
+        matches.
+
+        :param (str) query: Query string.
+        :returns (list): List of candidate matches.
+        """
+        possibles = self.index.get(query.lower())
+        if possibles:
+            return list(self.index.get(query))[:self.max_matches]
+        return []
+
+    def build_index(self):
+        """Build the search index.
+
+        Normalises the data set to all lower case and using the global
+        SUBSTITUTES list to remove/replace certain characters.  We then build
+        the two pivotal structures used for the index: `token_to_item` and
+        `n_gram_to_tokens`.
+
+        Note we use the original item word or phrase in the lookup but use the
+        normalised version to create the index tokens.
+        """
+        idx = defaultdict(set)
+        try:
+            with open(self.data_file, 'r') as f:
+                data = json.load(f)
+        except FileNotFoundError as e:
+            raise strategy.StrategyError(f'Failed to open data source: {e}')
+        except json.decoder.JSONDecodeError:
+            raise strategy.StrategyError(f'Data source is invalid: {e}')
+        for item in data:
+            norm_item = item.lower()
+            for substitute in strategy.SUBSTITUTES:
+                norm_item = norm_item.replace(substitute[0], substitute[1])
+            for i in range(0, len(norm_item)):
+                for string_size in range(Simple.MIN_N_GRAM_SIZE,
+                                         len(norm_item) + 1):
+                    n_gram = norm_item[i:string_size]
+                    idx[n_gram].add(item)
+        return idx

--- a/app/strategy.py
+++ b/app/strategy.py
@@ -21,6 +21,8 @@ SUBSTITUTES = [
     ('\u00e9', 'e'), ('\u00e8', 'e')
 ]
 
+INDEX_LOCATION = 'index'
+
 
 class Strategy:
     """Strategy."""
@@ -68,9 +70,10 @@ class Strategy:
     @staticmethod
     def index_name(path, strategy):
         """Build an index file name."""
-        if not os.path.exists('index'):
-            os.makedirs('index')
-        pth = os.path.join('index', path.split('.json')[0].replace('/', '_'))
+        if not os.path.exists(INDEX_LOCATION):
+            os.makedirs(INDEX_LOCATION)
+        pth = os.path.join(INDEX_LOCATION,
+                           path.split('.json')[0].replace('/', '_'))
         return f'{pth}_{strategy}.idx'
 
     @staticmethod

--- a/app/strategy.py
+++ b/app/strategy.py
@@ -1,0 +1,104 @@
+"""Strategy.
+
+Base definitions for a search strategy.
+"""
+import os
+import pickle
+
+
+class StrategyError(Exception):
+    """StrategyError
+
+    Raised when search strategy error occurs.
+    """
+    pass
+
+
+SUBSTITUTES = [
+    ('(', ''), (')', ''), (',', ' '), ('\'', ''), ('"', ''),
+    ('-', ' '), ('/', ' '), ('\\', ' '), ('_', ' '), (':', ' '),
+    ('\u2019', ''), ('\u00e5', 'a'), ('\u00e2', 'a'), ('\u00e7', 'c'),
+    ('\u00e9', 'e'), ('\u00e8', 'e')
+]
+
+
+class Strategy:
+    """Strategy."""
+    def __init__(self, data_file, strategy):
+        """Constructor.
+
+        :param (str) data_file: Path to the json file data source.
+        :param (str) strategy: Name of strategy.
+        """
+        self.data_file = data_file
+        self.strategy_name = strategy
+
+    def init(self):
+        """Initialise.
+
+        Load the index.  If there is no index, then invokes the `build_index`
+        implementation and stores the result.
+        """
+        idx_name = Strategy.index_name(self.data_file, self.strategy_name)
+        idx = Strategy.load_index(idx_name)
+        if not idx:
+            idx = self.build_index()
+            Strategy.store_index(idx_name, idx)
+        return idx
+
+    @staticmethod
+    def load_index(idx_name):
+        """Load the search index.
+
+        Attempts top load the search index if it exists.
+        :param (str) idx_name: Index file name.
+        :returns: The deserialized index if it exists otherwise None.
+        """
+        try:
+            with open(idx_name, 'rb') as f:
+                idx = pickle.load(f)
+        except FileNotFoundError:
+            return None
+        except Exception as e:
+            raise StrategyError(
+                f'Failed to load index for data source {e}')
+        else:
+            return idx
+
+    @staticmethod
+    def index_name(path, strategy):
+        """Build an index file name."""
+        if not os.path.exists('index'):
+            os.makedirs('index')
+        pth = os.path.join('index', path.split('.json')[0].replace('/', '_'))
+        return f'{pth}_{strategy}.idx'
+
+    @staticmethod
+    def store_index(path, idx):
+        try:
+            with open(path, 'wb') as f:
+                pickle.dump(idx, f, -1)
+        except Exception as e:
+            raise StrategyError(
+                f'Failed to create index: {path} Reason: {e}')
+
+    def build_index(self):
+        """Build the index.
+
+        Override this method to load the json data as specified by
+        `self.data_file` and build your index structure.
+        :returns: The freshly built index.
+        """
+        raise NotImplementedError()
+
+    def candidates(self, query):
+        """Get candidate matches.
+
+        Override this method to provide the main interface of a search
+        implementation. Given a query, your implementation should return
+        a list of candidate matches.
+
+        :param (str) query: Query string.
+        :returns (list): List of candidate matches.
+        """
+        raise NotImplementedError()

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -2,8 +2,22 @@
 
 App local `pytest` fixtures.
 """
+import mock
 import pytest
 import json
+
+import app.strategy as strategy
+
+
+@pytest.fixture
+def fake_strategy():
+
+    class FakeStrategy(strategy.Strategy):
+
+        def candidates(self, query):
+            return mock.Mock()
+
+    return FakeStrategy
 
 
 @pytest.fixture

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -21,7 +21,25 @@ def fake_strategy():
 
 
 @pytest.fixture
-def fake_data_set(tmpdir_factory):
+def data_set_file(request, tmpdir_factory):
+    """Fake data set file.
+
+    Creates a tmp file for fake data sets and additionally patches the index
+    path to a similar temp location.
+    """
+    index_loc = strategy.INDEX_LOCATION
+
+    def fin():
+        strategy.INDEX_LOCATION = index_loc
+
+    request.addfinalizer(fin)
+    ds = tmpdir_factory.mktemp('data').join('dataset.json')
+    strategy.INDEX_LOCATION = ds.dirname
+    return ds
+
+
+@pytest.fixture
+def fake_data_set(data_set_file):
     """Fake suggest api data set.
 
     Temp-file that contains the 'breakfast' data set.
@@ -32,11 +50,11 @@ def fake_data_set(tmpdir_factory):
         "Shitaki Mushrooms", "Fried Bread", "Fried Eggs", "Scrambled Eggs",
         "Poached Eggs", "Omelette", "Toast", "Raisin Toast", "Croissant"
     ]
-    ds = tmpdir_factory.mktemp('data').join('dataset.json')
-    ds.write('making sure file is created')
-    with open(str(ds), 'w') as f:
+    # ds = data_set_factory.mktemp('data').join('dataset.json')
+    data_set_file.write('making sure file is created')
+    with open(data_set_file.strpath, 'w') as f:
         json.dump(data_set_content, f)
-    return ds
+    return data_set_file
 
 
 @pytest.fixture
@@ -50,7 +68,7 @@ def fake_data_set_data(fake_data_set):
 
 
 @pytest.fixture
-def fake_data_set_large(tmpdir_factory):
+def fake_data_set_large(data_set_file):
     """Large fake suggest api data set.
 
     Temp-file that contains the larger, more complicated, unicode containing
@@ -96,15 +114,14 @@ def fake_data_set_large(tmpdir_factory):
                         "Turks and Caicos Islands",
                         "Virgin Islands of the United States", "Wake Island",
                         "Western Sahara", "\u00c5land Islands"]
-    ds = tmpdir_factory.mktemp('data').join('dataset.json')
-    ds.write('making sure file is created')
-    with open(str(ds), 'w') as f:
+    data_set_file.write('making sure file is created')
+    with open(data_set_file.strpath, 'w') as f:
         json.dump(data_set_content, f)
-    return ds
+    return data_set_file
 
 
 @pytest.fixture
-def fake_data_set_too_many_chiefs(tmpdir_factory):
+def fake_data_set_too_many_chiefs(data_set_file):
     """Large fake suggest api data set.
 
     Temp-file that contains a data set with items that will be similarly
@@ -131,20 +148,18 @@ def fake_data_set_too_many_chiefs(tmpdir_factory):
                         "Chief executive officer",
                         "Chief executive officer (government)",
                         "Chief executive officer (PO)"]
-    ds = tmpdir_factory.mktemp('data').join('dataset.json')
-    ds.write('making sure file is created')
-    with open(str(ds), 'w') as f:
+    data_set_file.write('making sure file is created')
+    with open(data_set_file.strpath, 'w') as f:
         json.dump(data_set_content, f)
-    return ds
+    return data_set_file
 
 
 @pytest.fixture
-def fake_data_set_invalid(tmpdir_factory):
+def fake_data_set_invalid(data_set_file):
     """Invalid fake suggest api data set.
 
     Temp-file that contains non-json data.
     """
     data_set_content = "I am really not json"
-    ds = tmpdir_factory.mktemp('data').join('invalid_dataset.json')
-    ds.write(data_set_content)
-    return ds
+    data_set_file.write(data_set_content)
+    return data_set_file

--- a/tests/app/test_guess.py
+++ b/tests/app/test_guess.py
@@ -189,14 +189,6 @@ def test_phrase_lookup_edits_single():
     assert set_total == len(single_edits)
 
 
-def test_phrase_lookup_edits_double():
-    term = 'word'
-    edits = PhraseLookup._single_edits(term)
-    double_edits = PhraseLookup._double_edits(term)
-    expected = set(e2 for e1 in edits for e2 in PhraseLookup._single_edits(e1))
-    assert double_edits - expected == set()
-
-
 def test_phrase_lookup_known(fake_data_set_data):
     p = PhraseLookup()
     p.prime(fake_data_set_data)

--- a/tests/app/test_strategy.py
+++ b/tests/app/test_strategy.py
@@ -1,0 +1,91 @@
+import mock
+import os
+import pickle
+import pytest
+
+import app.strategy as strategy
+
+
+def test_strategy_base():
+
+    class MyStrategy(strategy.Strategy):
+        pass
+
+    s = MyStrategy('/foo/bar', 'my_strat')
+    assert s.data_file == '/foo/bar'
+    assert s.strategy_name == 'my_strat'
+    with pytest.raises(NotImplementedError):
+        s.build_index()
+    with pytest.raises(NotImplementedError):
+        s.candidates('foo')
+
+
+def test_strategy_instance(monkeypatch, fake_strategy):
+    fake_index = [1, 2, 3]
+    mock_load = mock.Mock(return_value=fake_index)
+    mock_store = mock.Mock(return_value=None)
+    monkeypatch.setattr(strategy.Strategy, 'load_index', mock_load)
+    monkeypatch.setattr(strategy.Strategy, 'store_index', mock_store)
+    s = fake_strategy('data_set', 'strat')
+    idx = s.init()
+    assert idx == fake_index
+    fake_strategy.load_index.assert_called_with('index/data_set_strat.idx')
+    assert fake_strategy.store_index.called is False
+
+
+def test_strategy_instance_build(monkeypatch, fake_strategy, fake_data_set):
+    fake_index = [1, 2, 3, 4]
+    mock_load = mock.Mock(return_value=None)
+    mock_store = mock.Mock(return_value=None)
+    mock_build = mock.Mock(return_value=fake_index)
+    monkeypatch.setattr(strategy.Strategy, 'load_index', mock_load)
+    monkeypatch.setattr(strategy.Strategy, 'store_index', mock_store)
+    monkeypatch.setattr(strategy.Strategy, 'build_index', mock_build)
+    s = fake_strategy('data_set', 'strat')
+    idx = s.init()
+    assert idx == fake_index
+    fake_strategy.load_index.assert_called_with('index/data_set_strat.idx')
+    fake_strategy.store_index.assert_called_with('index/data_set_strat.idx',
+                                                 fake_index)
+
+
+def test_index_name(tmpdir_factory):
+    loc = tmpdir_factory.mktemp('my_index_location')
+    strategy.INDEX_LOCATION = str(loc)
+    idx_path = strategy.Strategy.index_name('data_set', 'strat')
+    assert idx_path == strategy.INDEX_LOCATION + '/data_set_strat.idx'
+
+
+def test_index_name_dir_creation(tmpdir_factory):
+    loc = tmpdir_factory.mktemp('root_location')
+    strategy.INDEX_LOCATION = os.path.join(str(loc), 'index')
+    idx_path = strategy.Strategy.index_name('data_set', 'strat')
+    assert os.path.exists(strategy.INDEX_LOCATION)
+    assert idx_path == strategy.INDEX_LOCATION + '/data_set_strat.idx'
+
+
+def test_load_no_index():
+    assert strategy.Strategy.load_index('foo') is None
+
+
+def test_load_bad_index(tmpdir_factory):
+    index_file = tmpdir_factory.mktemp('index').join('bad.idx')
+    index_file.write('not a pickle file')
+    with pytest.raises(strategy.StrategyError):
+        strategy.Strategy.load_index(str(index_file))
+
+
+def test_load_stored_index(tmpdir_factory):
+    index = [1, 2, 3]
+    index_file = tmpdir_factory.mktemp('index').join('lovely.idx')
+    strategy.Strategy.store_index(str(index_file), index)
+    assert strategy.Strategy.load_index(str(index_file)) == index
+
+
+def test_store_index_raises(monkeypatch):
+    monkeypatch.setattr(pickle, 'dump', mock.Mock(side_effect=RuntimeError))
+    with mock.patch(
+            'builtins.open', mock.mock_open(read_data='foo')) as mock_file:
+        with pytest.raises(strategy.StrategyError):
+            strategy.Strategy.store_index('idx_file', [1, 2, 3])
+        mock_file.assert_called_with('idx_file', 'wb')

--- a/tests/app/test_strategy.py
+++ b/tests/app/test_strategy.py
@@ -33,7 +33,7 @@ def test_strategy_instance(monkeypatch, fake_strategy):
     assert fake_strategy.store_index.called is False
 
 
-def test_strategy_instance_build(monkeypatch, fake_strategy, fake_data_set):
+def test_strategy_instance_build(monkeypatch, fake_strategy):
     fake_index = [1, 2, 3, 4]
     mock_load = mock.Mock(return_value=None)
     mock_store = mock.Mock(return_value=None)

--- a/tests/benchmark/response-times-guess.sh
+++ b/tests/benchmark/response-times-guess.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+declare -a terms=("teaching" "teaching assistant" "director" "managing director" "executive" "chief executive" 
+                  "chief" "farmer" "ass farmer" "sheep farmer" "Manufacturer" "Manufacturer basketry" 
+                  "Manufacturer joinery" "Manufacturer knit" "no such job ever")
+for term in "${terms[@]}"
+do
+   cmd="curl -sL http://localhost:5000/api/occupations/?s=guess&q=$term"
+   timing="$(time -p  ( $cmd )  2>&1 >/dev/null )"
+   t2=$(echo -e "$timing" | awk '/real/ {print $2}')
+   printf " %25s:  %10s\n" "$term" $t2
+done

--- a/tests/benchmark/response-times-simple.sh
+++ b/tests/benchmark/response-times-simple.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+declare -a terms=("the" "the republic" "new" "the dem" "feder" "federation" 
+                  "social" "social unioin" "yugoslavia" "yugosl" "the king" "ithe kingdom" 
+                  "zanadu" "xanadu" "pastry")
+for term in "${terms[@]}"
+do
+   cmd="curl -sL http://localhost:5000/api/countries_official_names/?s=simple&q=$term"
+   timing="$(time -p  ( $cmd  ) 2>&1 1>/dev/null )"
+   t2=$(echo -e "$timing" | awk '/real/ {print $2}')
+   printf " %25s:  %10s\n" "$term" $t2
+done


### PR DESCRIPTION
### What is the context of this PR?
Review of the initial implementation gave rise to the observation that some search results were unexpected due to the range of misspellings created for the index.  Additionally the API was considered too slow for typeahead usage.  Refactored to:

- Enable multiple search strategies and modified guess strategy to just use additions and deletions in the index to make responses more predictable.
- Lazily cache index to improve performance.

### How to review
- Run tests
- Examine data and responses using [deployed ECS instance](http://davec.dev.eq.ons.digital/api)
- Examine responses using  [UI Prototype](https://deploy-preview-80--eq-prototypes.netlify.com/) and visit the `Suggest` prototype pages.
